### PR TITLE
theme(atomic): add a space between the gear icon and formatted time

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -59,7 +59,7 @@
             "threshold": 0
           },
           "style": "diamond",
-          "template": " \ueba2{{ .FormattedMs }}\u2800",
+          "template": " \ueba2 {{ .FormattedMs }}\u2800",
           "trailing_diamond": "\ue0b4",
           "type": "executiontime"
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary


The command execution duration and the gear icon overlapped on my system (Windows Terminal, CaskaydiaCove Nerd Font), as shown in the image.

![image](https://github.com/shravanasati/oh-my-posh/assets/69118069/395d383d-47da-42da-9d30-5fc3c705786e)

After adding a space between the symbol and the formatted time, it no longer overlaps and is perfectly visible.

![image](https://github.com/shravanasati/oh-my-posh/assets/69118069/c5623d75-7ada-4c3f-9ea2-0a1f6b76e6ec)

Not sure if this is just the case for me, I tried fixing it locally but every update reverts the change.